### PR TITLE
Updated for SDK 2.14.x and newer

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -25,4 +25,10 @@ SDK : 2.12.1
    These files are already a part of SDK release 2.12.1 and can be found under
 Ex: SDK_2_12_1_MIMXRT1170-EVK\components\wifi_bt_module\Murata\tx_pwr_limits
 
+SDK : 2.14.x or newer
+=====================
+   These file are not included in the SDK release (except WW files) and must be
+downloaded by the user and placed in the correct location to use.
+Ex: SDK_2_15_000_EVK-MIMXRT1060\components\wifi_bt_module\Murata\tx_pwr_limits
+
 

--- a/wlan_txpwrlimit_cfg_murata_1XK_CA.h
+++ b/wlan_txpwrlimit_cfg_murata_1XK_CA.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_CA_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_CA_H_
+
+#define WLAN_REGION_CODE "CA"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 11,
     .chan_info[0] =
@@ -607,3 +612,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_5g_cfg =
             },
 };
 #endif /* CONFIG_5GHz_SUPPORT */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_CA_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1XK_EU.h
+++ b/wlan_txpwrlimit_cfg_murata_1XK_EU.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_EU_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_EU_H_
+
+#define WLAN_REGION_CODE "EU"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 13,
     .chan_info[0] =
@@ -675,3 +680,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_5g_cfg =
             },
 };
 #endif /* CONFIG_5GHz_SUPPORT */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_EU_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1XK_JP.h
+++ b/wlan_txpwrlimit_cfg_murata_1XK_JP.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_JP_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_JP_H_
+
+#define WLAN_REGION_CODE "JP"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 13,
     .chan_info[0] =
@@ -607,3 +612,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_5g_cfg =
             },
 };
 #endif /* CONFIG_5GHz_SUPPORT */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_JP_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1XK_US.h
+++ b/wlan_txpwrlimit_cfg_murata_1XK_US.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_US_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_US_H_
+
+#define WLAN_REGION_CODE "US"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 11,
     .chan_info[0] =
@@ -657,3 +662,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_5g_cfg =
             },
 };
 #endif /* CONFIG_5GHz_SUPPORT */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_US_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1XK_WW.h
+++ b/wlan_txpwrlimit_cfg_murata_1XK_WW.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_WW_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_WW_H_
+
+#define WLAN_REGION_CODE "WW"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 14,
     .chan_info[0] =
@@ -708,3 +713,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_5g_cfg =
             },
 };
 #endif /* CONFIG_5GHz_SUPPORT */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1XK_WW_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1ZM_CA.h
+++ b/wlan_txpwrlimit_cfg_murata_1ZM_CA.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_CA_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_CA_H_
+
+#define WLAN_REGION_CODE "CA"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 11,
     .chan_info[0] =
@@ -1484,3 +1489,5 @@ static wifi_txpwrlimit_t
 };
 #endif /* CONFIG_5GHz_SUPPORT */
 #endif /* CONFIG_11AC */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_CA_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1ZM_EU.h
+++ b/wlan_txpwrlimit_cfg_murata_1ZM_EU.h
@@ -23,6 +23,12 @@
  *  express and approved by NXP in writing.
  *
  */
+
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_EU_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_EU_H_
+
+#define WLAN_REGION_CODE "EU"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 13,
     .chan_info[0] =
@@ -1660,3 +1666,5 @@ static wifi_txpwrlimit_t
 };
 #endif /* CONFIG_5GHz_SUPPORT */
 #endif /* CONFIG_11AC */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_EU_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1ZM_JP.h
+++ b/wlan_txpwrlimit_cfg_murata_1ZM_JP.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_JP_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_JP_H_
+
+#define WLAN_REGION_CODE "JP"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 13,
     .chan_info[0] =
@@ -1462,3 +1467,5 @@ static wifi_txpwrlimit_t
 };
 #endif /* CONFIG_5GHz_SUPPORT */
 #endif /* CONFIG_11AC */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_JP_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1ZM_US.h
+++ b/wlan_txpwrlimit_cfg_murata_1ZM_US.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_US_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_US_H_
+
+#define WLAN_REGION_CODE "US"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 11,
     .chan_info[0] =
@@ -1619,3 +1624,5 @@ static wifi_txpwrlimit_t
 };
 #endif /* CONFIG_5GHz_SUPPORT */
 #endif /* CONFIG_11AC */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_US_H_ */

--- a/wlan_txpwrlimit_cfg_murata_1ZM_WW.h
+++ b/wlan_txpwrlimit_cfg_murata_1ZM_WW.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_WW_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_WW_H_
+
+#define WLAN_REGION_CODE "WW"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 14,
     .chan_info[0] =
@@ -1546,3 +1551,5 @@ static wifi_txpwrlimit_t
 };
 #endif /* CONFIG_5GHz_SUPPORT */
 #endif /* CONFIG_11AC */
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_1ZM_WW_H_ */

--- a/wlan_txpwrlimit_cfg_murata_2DS_CA.h
+++ b/wlan_txpwrlimit_cfg_murata_2DS_CA.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_CA_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_CA_H_
+
+#define WLAN_REGION_CODE "CA"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 11,
     .chan_info[0] =
@@ -219,3 +224,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_2g_cfg = {
             .txpwrlimit_entry = {{0, 17}, {1, 12}, {2, 12}, {3, 12}, {4, 11}, {5, 11}, {6, 11}, {7, 0}, {8, 0}, {9, 0}},
         },
 };
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_CA_H_ */

--- a/wlan_txpwrlimit_cfg_murata_2DS_EU.h
+++ b/wlan_txpwrlimit_cfg_murata_2DS_EU.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_EU_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_EU_H_
+
+#define WLAN_REGION_CODE "EU"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 13,
     .chan_info[0] =
@@ -253,3 +258,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_2g_cfg = {
             .txpwrlimit_entry = {{0, 12}, {1, 13}, {2, 13}, {3, 13}, {4, 13}, {5, 13}, {6, 13}, {7, 0}, {8, 0}, {9, 0}},
         },
 };
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_EU_H_ */

--- a/wlan_txpwrlimit_cfg_murata_2DS_JP.h
+++ b/wlan_txpwrlimit_cfg_murata_2DS_JP.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_JP_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_JP_H_
+
+#define WLAN_REGION_CODE "JP"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 13,
     .chan_info[0] =
@@ -253,3 +258,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_2g_cfg = {
             .txpwrlimit_entry = {{0, 14}, {1, 15}, {2, 14}, {3, 14}, {4, 15}, {5, 15}, {6, 14}, {7, 0}, {8, 0}, {9, 0}},
         },
 };
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_JP_H_ */

--- a/wlan_txpwrlimit_cfg_murata_2DS_US.h
+++ b/wlan_txpwrlimit_cfg_murata_2DS_US.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_US_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_US_H_
+
+#define WLAN_REGION_CODE "US"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 11,
     .chan_info[0] =
@@ -219,3 +224,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_2g_cfg = {
             .txpwrlimit_entry = {{0, 17}, {1, 12}, {2, 12}, {3, 12}, {4, 11}, {5, 11}, {6, 11}, {7, 0}, {8, 0}, {9, 0}},
         },
 };
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_US_H_ */

--- a/wlan_txpwrlimit_cfg_murata_2DS_WW.h
+++ b/wlan_txpwrlimit_cfg_murata_2DS_WW.h
@@ -24,6 +24,11 @@
  *
  */
 
+#ifndef _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_WW_H_
+#define _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_WW_H_
+
+#define WLAN_REGION_CODE "WW"
+
 static wlan_chanlist_t chanlist_2g_cfg = {
     .num_chans = 14,
     .chan_info[0] =
@@ -271,3 +276,5 @@ static wifi_txpwrlimit_t tx_pwrlimit_2g_cfg =
                 .txpwrlimit_entry = {{0, 8}, {1, 0}, {2, 0}, {3, 0}, {4, 0}, {5, 0}, {6, 0}, {7, 0}, {8, 0}, {9, 0}},
             },
 };
+
+#endif /* _WLAN_TXPWRLIMIT_CFG_MURATA_2DS_WW_H_ */


### PR DESCRIPTION
Updated the header files to make them compatible with SDK 2.14.x or newer. These header files (with the exception of WW files) are no longer provided with the SDK.